### PR TITLE
fix crash when dealloc happens before viewWillAppear

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # SLPagingView
-[![Build Status](https://travis-ci.org/StefanLage/SLPagingView.svg?branch=master)](https://travis-ci.org/StefanLage/SLPagingView)
-[![Version](https://img.shields.io/cocoapods/v/SLPagingView.svg?style=flat)](http://cocoadocs.org/docsets/SLPagingView)
-[![License](https://img.shields.io/cocoapods/l/SLPagingView.svg?style=flat)](http://cocoadocs.org/docsets/SLPagingView)
 
 A navigation bar system allowing to do a Tinder like or Twitter like.
 
@@ -10,181 +7,14 @@ A navigation bar system allowing to do a Tinder like or Twitter like.
 <img src="Demos/TwitterLike/twitter.gif" algin="right" height="440" width="250" style="margin-left:50px;">
 </div>
 
-## Requirements
+## Fork Changes
 
-* iOS 7.0+ 
-* ARC
+* View Controller Containment
+* Full screen (UIViewControllers show behind translucent bar)
 
-## Installation
+## TODO
 
-### CocoaPods
-
-[CocosPods](http://cocosPods.org) is the recommended method to install SLPagingView.
-
-Add the following line to your Podfile:
-
-```ruby
-pod 'SLPagingView'
-```
-
-And run
-```ruby
-pod install
-```
-
-### Manual
-
-Import SLPagingView folder into your project.
-
-
-## How to use
-
-Easy to implement:
-
-```` objective-c
-
-	// Make views for the navigation bar
-    UIImage *img1 = [UIImage imageNamed:@"gear"];
-    img1 = [img1 imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-    
-    UIImage *img2 = [UIImage imageNamed:@"profile"];
-    img2 = [img2 imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-    
-    UIImage *img3 = [UIImage imageNamed:@"chat"];
-    img3 = [img3 imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-    
-    NSArray *titles = @[[[UIImageView alloc] initWithImage:img1], [[UIImageView alloc] initWithImage:img2], [[UIImageView alloc] initWithImage:img3]];
-    NSArray *views = @[[self viewWithBackground:orange], [self viewWithBackground:[UIColor yellowColor]], [self viewWithBackground:gray]];
-    
-    SLPagingViewController *pageViewController = [[SLPagingViewController alloc] initWithNavBarItems:titles
-                                                                                    navBarBackground:[UIColor whiteColor]
-                                                                                               views:views
-                                                                                     showPageControl:NO];
-
-````
-
-Then you can make your own behaviors:
-
-````objective-c
-
-	// Tinder Like
-    pageViewController.pagingViewMovingRedefine = ^(UIScrollView *scrollView, NSArray *subviews){
-        int i = 0;
-        for(UIImageView *v in subviews){
-            UIColor *c = gray;
-            if(v.frame.origin.x > 45
-               && v.frame.origin.x < 145)
-                // Left part
-                c = [self gradient:v.frame.origin.x
-                               top:46
-                            bottom:144
-                              init:orange
-                              goal:gray];
-            else if(v.frame.origin.x > 145
-                    && v.frame.origin.x < 245)
-                // Right part
-                c = [self gradient:v.frame.origin.x
-                               top:146
-                            bottom:244
-                              init:gray
-                              goal:orange];
-            else if(v.frame.origin.x == 145)
-                c = orange;
-            v.tintColor= c;
-            i++;
-        }
-     };
-
-````
-
-##Other sample
-
-Twitter like behaviors
-
-````objective-c
-
-	// Twitter Like
-    pageViewController.pagingViewMovingRedefine = ^(UIScrollView *scrollView, NSArray *subviews){
-        CGFloat xOffset = scrollView.contentOffset.x;
-        int i = 0;
-        for(UILabel *v in subviews){
-            CGFloat alpha = 0.0;
-            if(v.frame.origin.x < 145)
-                alpha = 1 - (xOffset - i*320) / 320;
-            else if(v.frame.origin.x >145)
-                alpha=(xOffset - i*320) / 320 + 1;
-            else if(v.frame.origin.x == 140)
-                alpha = 1.0;
-            i++;
-            v.alpha = alpha;
-        }
-    };
-````
-
-##API
-
-###Set current page
-
-If you want to changed the default page control index (or whatever) you can do it calling:
-
-````objective-c
-
-	-(void)setCurrentIndex:(NSInteger)index animated:(BOOL)animated;
-````
-
-###Navigation items style
-
-<img src="Demos/TinderLike/navigation_style.gif" height="440" width="250" style="margin-left:50px;">
-
-You can easily customized the navigation items setting up:
-
-
-````objective-c
-
-	@property (nonatomic) SLNavigationSideItemsStyle navigationSideItemsStyle;
-````
-
-
-By using one of these values:
-
-
-````objective-c
-
-	typedef NS_ENUM(NSInteger, SLNavigationSideItemsStyle) {
-		SLNavigationSideItemsStyleOnBounds,
-		SLNavigationSideItemsStyleClose,
-		SLNavigationSideItemsStyleNormal,
-		SLNavigationSideItemsStyleFar,
-		SLNavigationSideItemsStyleDefault,
-		SLNavigationSideItemsStyleCloseToEachOne
-	};
-````
-
-###Set navigation bar's background color
-
-You can update the background color of the navigation bar using the following method:
-
-````objective-c
-
-	setNavigationBarColor:(UIColor*) color;
-````
-
-##Storyboard support
-
-This class can be implemented using Storyboard.
-You need to set all identifiers of the segues linked to your SLPagingViewController respecting this syntax: 
-` sl_X where X ∈ [0..N] `.
-
-X corresponding to the index of the view, start from 0 and it works in ascending order.
-
-![segue](Demos/TinderStoryboard/segue_params.png)
-
-You can find an example "TinderStoryboard" for more informations.
-
-###Set navigation bar's background color
-To set up the navigation bar's background color from the storyboard, you just need to it like all navigation bar.
-
-![segue](Demos/TinderStoryboard/navigation_bar_color.png)
+* Make custom bar view part of the navigation item
 
 ##License
-Available under MIT license, please read LICENSE for more informations.
+Available under MIT license, please read LICENSE for more information.

--- a/SLPagingView.podspec
+++ b/SLPagingView.podspec
@@ -2,10 +2,10 @@ Pod::Spec.new do |s|
 	s.name = 'SLPagingView'
 	s.version = '0.0.5'
 	s.summary = 'Navigation bar system allowing to do a Tinder like or Twitter like'
-	s.homepage = 'https://github.com/StefanLage/SLPagingView'
+	s.homepage = 'https://github.com/ankorko/SLPagingView'
 	s.license = 'MIT'
-	s.author = { 'StefanLage' => 'lagestfan@gmail.com' }
-	s.source = { :git => 'https://github.com/StefanLage/SLPagingView.git', :tag => "#{s.version}" }
+	s.author = { 'ankorko' => 'ankorko@gmail.com' }
+	s.source = { :git => 'https://github.com/ankorko/SLPagingView.git', :tag => "#{s.version}" }
 	s.source_files = 'SLPagingView/**/*.{h,m}'
 	s.requires_arc = true
 	s.platform = :ios, '7.0'

--- a/SLPagingView/SLPagingViewController.h
+++ b/SLPagingView/SLPagingViewController.h
@@ -58,7 +58,7 @@ typedef void(^SLPagingViewDidChanged)(NSInteger currentPage);
 /*
  *  Contains all views displayed
  */
-@property (nonatomic, strong) NSMutableDictionary *viewControllers;
+@property (nonatomic, strong) NSMutableDictionary *viewsDict;
 /*
  *  Tint color of the page control
  */

--- a/SLPagingView/SLPagingViewController.h
+++ b/SLPagingView/SLPagingViewController.h
@@ -55,6 +55,13 @@ typedef void(^SLPagingViewDidChanged)(NSInteger currentPage);
  *  @param currentPage
  */
 @property (nonatomic, copy) SLPagingViewDidChanged didChangedPage;
+
+/*
+ * Contains all child view controllers 
+ * if initialized with controlles not views
+ */
+@property (nonatomic, strong) NSMutableDictionary *viewControllersDict;
+
 /*
  *  Contains all views displayed
  */

--- a/SLPagingView/SLPagingViewController.m
+++ b/SLPagingView/SLPagingViewController.m
@@ -183,6 +183,9 @@
                                                  name:UIDeviceOrientationDidChangeNotification
                                                object:nil];
     [self.navigationController.navigationBar addSubview:self.navigationBarView];
+    // call once manually to update items and execute custom behaviour blocks
+    // for initial setup
+    [self scrollViewDidScroll:self.scrollView];
 }
 
 -(void)viewWillDisappear:(BOOL)animated{

--- a/SLPagingView/SLPagingViewController.m
+++ b/SLPagingView/SLPagingViewController.m
@@ -215,8 +215,10 @@
 
 -(void)dealloc{
     // Remove Observers
-    [[NSNotificationCenter defaultCenter]removeObserver:self
-                                             forKeyPath:UIDeviceOrientationDidChangeNotification];
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:UIDeviceOrientationDidChangeNotification
+                                                  object:nil];
+
     // Close relationships
     _didChangedPage           = nil;
     _pagingViewMoving         = nil;

--- a/SLPagingView/SLPagingViewController.m
+++ b/SLPagingView/SLPagingViewController.m
@@ -166,6 +166,7 @@
     [self notifyControllers:NSSelectorFromString(@"loadView")
                      object:nil
                  checkIndex:NO];
+    self.automaticallyAdjustsScrollViewInsets = NO;
     // Try to load controller from storyboard
     [self loadStoryboardControllers];
     // Set up the controller
@@ -364,15 +365,16 @@
 
 -(void)setupPagingProcess{
     // Make our ScrollView
-    CGRect frame                                              = CGRectMake(0, 0, SCREEN_SIZE.width, self.view.bounds.size.height);
-    self.scrollView                                           = [[UIScrollView alloc] initWithFrame:frame];
+    CGRect frame                                              = self.view.bounds;
+    UIScrollView *someScrollView = [[UIScrollView alloc] initWithFrame:frame];
+    self.scrollView                                           = someScrollView;
     self.scrollView.backgroundColor                           = [UIColor clearColor];
     self.scrollView.pagingEnabled                             = YES;
     self.scrollView.showsHorizontalScrollIndicator            = NO;
     self.scrollView.showsVerticalScrollIndicator              = NO;
     self.scrollView.delegate                                  = self;
     self.scrollView.bounces                                   = NO;
-    [self.scrollView setContentInset:UIEdgeInsetsMake(0, 0, -80, 0)];
+    //[self.scrollView setContentInset:UIEdgeInsetsMake(0, 0, -80, 0)];
     [self.view addSubview:self.scrollView];
     
     // Adds all views
@@ -395,7 +397,7 @@
     if(self.viewsDict
        && self.viewsDict.count > 0){
         float width                 = SCREEN_SIZE.width * self.viewsDict.count;
-        float height                = CGRectGetHeight(self.view.bounds) - CGRectGetHeight(self.navigationBarView.bounds);
+        float height                = CGRectGetHeight(self.scrollView.frame);
         self.scrollView.contentSize = (CGSize){width, height};
         __block int i = 0;
         // Sort all keys in ascending
@@ -424,31 +426,20 @@
                                                                            multiplier:1.0
                                                                              constant:0]];
                 // Height constraint, half of parent view height
-                [self.scrollView addConstraint:[NSLayoutConstraint constraintWithItem:v
-                                                                            attribute:NSLayoutAttributeHeight
-                                                                            relatedBy:NSLayoutRelationEqual
-                                                                               toItem:self.scrollView
-                                                                            attribute:NSLayoutAttributeHeight
-                                                                           multiplier:1.0
-                                                                             constant:0]];
-                UIView *previous = [self.viewsDict objectForKey:[NSNumber numberWithFloat:(idx - 1)]];
-                if(previous)
-                    // Distance constraint: set distance between previous view and the current one
-                    [self.scrollView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:[previous]-0-[v]"
-                                                                                            options:0
-                                                                                            metrics:nil
-                                                                                              views:@{@"v" : v, @"previous" : previous}]];
-                else
-                    // First view
-                    [self.scrollView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-0-[v]"
-                                                                                            options:0
-                                                                                            metrics:nil
-                                                                                              views:@{@"v" : v }]];
-                // Oridnate constraint : set the space between the Top and the current view
-                [self.scrollView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"V:|-%f-[v]", CGRectGetHeight(self.navigationBarView.frame)]
-                                                                                        options:0
-                                                                                        metrics:nil
-                                                                                          views:@{@"v" : v}]];
+                [self.scrollView addConstraint:
+                 [NSLayoutConstraint constraintWithItem:v
+                                              attribute:NSLayoutAttributeHeight
+                                              relatedBy:NSLayoutRelationEqual
+                                                 toItem:self.scrollView
+                                              attribute:NSLayoutAttributeHeight
+                                             multiplier:1.0
+                                               constant:0]];
+                
+                [self.scrollView addConstraints:
+                 [NSLayoutConstraint constraintsWithVisualFormat:[NSString stringWithFormat:@"H:|-%f-[v]", self.view.frame.size.width * idx]
+                                                         options:0
+                                                         metrics:nil
+                                                           views:@{@"v" : v}]];
                 }
             else{
                 v.frame = (CGRect){SCREEN_SIZE.width * i, 0, SCREEN_SIZE.width, CGRectGetHeight(self.view.frame)};

--- a/SLPagingView/SLPagingViewController.m
+++ b/SLPagingView/SLPagingViewController.m
@@ -399,7 +399,6 @@
         float width                 = SCREEN_SIZE.width * self.viewsDict.count;
         float height                = CGRectGetHeight(self.scrollView.frame);
         self.scrollView.contentSize = (CGSize){width, height};
-        __block int i = 0;
         // Sort all keys in ascending
         NSArray *sortedIndexes = [self.viewsDict.allKeys sortedArrayUsingComparator:^NSComparisonResult(NSNumber *key1, NSNumber *key2) {
             if ([key1 integerValue] > [key2 integerValue]) {
@@ -442,8 +441,7 @@
                                                            views:@{@"v" : v}]];
                 }
             else{
-                v.frame = (CGRect){SCREEN_SIZE.width * i, 0, SCREEN_SIZE.width, CGRectGetHeight(self.view.frame)};
-                i++;
+                v.frame = (CGRect){SCREEN_SIZE.width * idx, 0, SCREEN_SIZE.width, CGRectGetHeight(self.view.frame)};
             }
         }];
     }

--- a/SLPagingView/SLPagingViewController.m
+++ b/SLPagingView/SLPagingViewController.m
@@ -78,7 +78,7 @@
             }
             // Number of keys equals number of controllers ?
             if(controllerKeys.count == views.count)
-                _viewControllers = [[NSMutableDictionary alloc] initWithObjects:views
+                _viewsDict = [[NSMutableDictionary alloc] initWithObjects:views
                                                                         forKeys:controllerKeys];
             else{
                 // Something went wrong -> inform the client
@@ -258,7 +258,7 @@
 }
 
 -(void)addViewControllers:(UIViewController *) controller needToRefresh:(BOOL) refresh{
-    int tag = (int)self.viewControllers.count;
+    int tag = (int)self.viewsDict.count;
     // Try to get a navigation item
     UIView *v = nil;
     if(controller.title){
@@ -278,7 +278,7 @@
     [self addNavigationItem:v
                         tag:tag];
     // Save the controller
-    [self.viewControllers setObject:controller.view
+    [self.viewsDict setObject:controller.view
                              forKey:@(tag)];
     // Update controller's hierarchy
     [self addChildViewController:controller];
@@ -302,7 +302,7 @@
     _isUserInteraction                 = YES;
     // Default value for the navigation style
     _navigationSideItemsStyle          = SLNavigationSideItemsStyleDefault;
-    _viewControllers                   = [NSMutableDictionary new];
+    _viewsDict                   = [NSMutableDictionary new];
     _navItemsViews                     = [NSMutableArray new];
 }
 
@@ -392,14 +392,14 @@
 
 // Add all views
 -(void)addControllers{
-    if(self.viewControllers
-       && self.viewControllers.count > 0){
-        float width                 = SCREEN_SIZE.width * self.viewControllers.count;
+    if(self.viewsDict
+       && self.viewsDict.count > 0){
+        float width                 = SCREEN_SIZE.width * self.viewsDict.count;
         float height                = CGRectGetHeight(self.view.bounds) - CGRectGetHeight(self.navigationBarView.bounds);
         self.scrollView.contentSize = (CGSize){width, height};
         __block int i = 0;
         // Sort all keys in ascending
-        NSArray *sortedIndexes = [self.viewControllers.allKeys sortedArrayUsingComparator:^NSComparisonResult(NSNumber *key1, NSNumber *key2) {
+        NSArray *sortedIndexes = [self.viewsDict.allKeys sortedArrayUsingComparator:^NSComparisonResult(NSNumber *key1, NSNumber *key2) {
             if ([key1 integerValue] > [key2 integerValue]) {
                 return (NSComparisonResult)NSOrderedDescending;
             }
@@ -410,7 +410,7 @@
         }];
 
         [sortedIndexes enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-            UIView *v = self.viewControllers[@(idx)];
+            UIView *v = self.viewsDict[@(idx)];
             [self.scrollView addSubview:v];
             if([self useAutoLayout:v]){
                 // Using AutoLayout
@@ -431,7 +431,7 @@
                                                                             attribute:NSLayoutAttributeHeight
                                                                            multiplier:1.0
                                                                              constant:0]];
-                UIView *previous = [self.viewControllers objectForKey:[NSNumber numberWithFloat:(idx - 1)]];
+                UIView *previous = [self.viewsDict objectForKey:[NSNumber numberWithFloat:(idx - 1)]];
                 if(previous)
                     // Distance constraint: set distance between previous view and the current one
                     [self.scrollView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:[previous]-0-[v]"
@@ -462,7 +462,7 @@
 -(void)tapOnHeader:(UITapGestureRecognizer *)recognizer{
     if(self.isUserInteraction){
         // Get the wanted view
-        UIView *view = [self.viewControllers objectForKey:@(recognizer.view.tag)];
+        UIView *view = [self.viewsDict objectForKey:@(recognizer.view.tag)];
         [self.scrollView scrollRectToVisible:view.frame
                                     animated:YES];
     }


### PR DESCRIPTION
If the SLPagingViewController is deallocated before being shown, it crashes when it tries to remove itself as observer. For example:

```
SLPagingViewController *pagingVC  = [[SLPagingViewController alloc]
                                                                initWithNavBarItems:navigationItems
                                                                controllers:controllers];
LoginViewController *loginVC = [[LoginViewController alloc] init];
UIViewController *next = isUserLoggedIn ? pagingVC : loginVC;
[self.navigationController setViewControllers:@[next]];
```

crashes if (isUserLoggedIn == NO)
